### PR TITLE
add standalone tag to flat structure codes

### DIFF
--- a/parse_and_import_medicover.py
+++ b/parse_and_import_medicover.py
@@ -313,7 +313,7 @@ def main(
                                 try:
                                     strength = code.split("_")[1].title()
                                 except IndexError:
-                                    strength = None
+                                    strength = "Stand-Alone"
                                 if reformatted_code.upper() in ACGS_CODES:
                                     parsed_variant_data[
                                     reformatted_code.lower()


### PR DESCRIPTION
I was setting strength to null in flat jsons where the code was just e.g. "PM2" (i.e. no strength label) but this makes it look like the criterion hasn't been applied once imported into the db. Now sets to "Stand-Alone" instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/medicover_aws/5)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of codes without explicit strength information to now default to "Stand-Alone" instead of remaining undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->